### PR TITLE
Various cleanup and removal of indirection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ install-bin: $(BIN)
 
 uninstall:
 ifneq (, $(wildcard $(MANDEST)/$(DOC).gz))
-	rm $(MANDEST)/$(DOC).gz 
+	rm $(MANDEST)/$(DOC).gz
 endif
 ifneq (, $(wildcard $(BINDEST)/$(BIN)))
 	rm $(BINDEST)/$(BIN)
@@ -66,10 +66,10 @@ endif
 
 # Building
 $(BIN): $(CSRC) $(HEADERS)
-	$(CC) -o $(BIN) $(CFLAGS) $(CSRC) 
+	$(CC) -o $(BIN) $(CFLAGS) $(CSRC)
 
 # Cleaning
-clean: 
+clean:
 ifneq (, $(wildcard $(BIN)))
 	rm $(BIN)
 else

--- a/README
+++ b/README
@@ -46,7 +46,7 @@ To build and install the program *without* documentation run:
 make
 sudo make install-bin
 
-Per is also available in Arch User Repository (https://aur.archlinux.org/packages/per/). 
+Per is also available in Arch User Repository (https://aur.archlinux.org/packages/per/).
 It will always be up to date with the latest release.
 
 Building was tested and works on: Slackware, Artix, Arch, OpenBSD, NixOS and macOS.

--- a/conv.c
+++ b/conv.c
@@ -1,6 +1,6 @@
 // vim: ts=2 shiftwidth=2 noexpandtab
 
-/* 
+/*
  * per - Simple unix permission viewer and converter
  *
  * This program is licensed under GPL version 3.
@@ -30,7 +30,7 @@ numeric_to_symbolic(uint16_t num) {
 		for (unsigned int i = 0; i < 3; i++) {
 			/* Check if nth bit frm the beginning is 1 */
 			if (num & (1 << (11 - i))) {
-				/* 
+				/*
 				 * Check if corresponding bit from non-special notation is empty
 				 * and apply uppercase or lowercase char appropriately.
 				 */

--- a/misc.c
+++ b/misc.c
@@ -1,6 +1,6 @@
 // vim: ts=2 shiftwidth=2 noexpandtab
 
-/* 
+/*
  * per - Simple unix permission viewer and converter
  *
  * This program is licensed under GPL version 3.
@@ -39,7 +39,7 @@ symbolicp(char *str) {
 							str[i] != chars_spec_upp[i / 3]) {
 						return (FALSE);
 					}
-				} 
+				}
 				else return (FALSE);
 			}
 		}

--- a/per.c
+++ b/per.c
@@ -1,6 +1,6 @@
 // vim: ts=2 shiftwidth=2 noexpandtab
 
-/* 
+/*
  * per - Simple unix permission viewer and converter
  *
  * This program is licensed under GPL version 3.
@@ -104,9 +104,9 @@ new_perm_from_value(char *target) {
 		ERR(1, EINVAL, "Incorrect numeric notation");
 	}
 
-	/* 
+	/*
 	 * Checking if there weren't any strings in ``TARGET'' i.e. runs if
-	 * ``TARGET'' is a number. 
+	 * ``TARGET'' is a number.
 	 */
 	if (*endptr == '\0') {
 		perm->numeric = (uint16_t) numeric;
@@ -117,7 +117,7 @@ new_perm_from_value(char *target) {
 	else if (!access(target, F_OK)) {
 		struct stat statbuf;
 
-		/* 
+		/*
 		 * Possible race condition, file could've been modified between access()
 		 * and stat().
 		 */

--- a/per.c
+++ b/per.c
@@ -32,14 +32,12 @@ main(int argc, char **argv) {
 
 	/* If only one arg is supplied respawn with `-vns' */
 	if (argc == 2) {
-		char *argv_respawn[] = { argv[0], "-vns", argv[1], NULL };
-		execvp(argv[0], argv_respawn);
+		execl(argv[0], argv[0], "-vns", argv[1], NULL);
 	}
 
 	/* The same as above but runs when only `-S' is passed */
 	if (argc == 3 && (strcmp(argv[1], "-S")) == 0) {
-		char *argv_respawn[] = { argv[0], "-Svns", argv[2], NULL };
-		execvp(argv[0], argv_respawn);
+		execl(argv[0], argv[0], "-Svns", argv[2], NULL);
 	}
 
 	/* Allocate space for permissions converted into a struct */
@@ -62,11 +60,11 @@ main(int argc, char **argv) {
 				break;
 			case 'n':
 				if (!perm->initialized) perm = new_perm_from_value(target);
-				print_numeric(perm);
+				printf("%0*o\n", specialp ? 4 : 3, perm->numeric);
 				break;
 			case 's':
 				if (!perm->initialized) perm = new_perm_from_value(target);
-				print_symbolic(perm);
+				puts(perm->symbolic);
 				break;
 			case 'v':
 				if (!perm->initialized) perm = new_perm_from_value(target);
@@ -75,11 +73,9 @@ main(int argc, char **argv) {
 			case 'h':
 				usage();
 				exit(0);
-				break;
 			default:
 				usage();
 				exit(1);
-				break;
 		}
 	}
 
@@ -89,9 +85,7 @@ main(int argc, char **argv) {
 Perm *
 new_perm_from_value(char *target) {
 	/* N of bits (12 for special, 9 for normal) */
-	int bitn;
-	if (specialp) bitn = 12;
-	else					bitn = 9;
+	int bitn = specialp ? 12 : 9;
 	
 	/* calloc will set mem to 0 */
 	Perm *perm = calloc(1, sizeof(Perm));

--- a/per.h
+++ b/per.h
@@ -1,6 +1,6 @@
 // vim: ts=2 shiftwidth=2 noexpandtab
 
-/* 
+/*
  * per - Simple unix permission viewer and converter
  *
  * This program is licensed under GPL version 3.
@@ -33,7 +33,7 @@
 /* Permision from the arg is converted into this struct */
 typedef struct __perm {
 	uint16_t		numeric;
-	char			 *symbolic; 
+	char			 *symbolic;
 	_Bool				initialized;
 } Perm;
 
@@ -57,7 +57,7 @@ void				usage									 ();
 /* conv.c */
 char			 *numeric_to_symbolic		 (uint16_t num);
 uint16_t		symbolic_to_numeric		 (char* str);
-char			 *numeric_to_verbose		 (unsigned int octal, char* read_str, 
+char			 *numeric_to_verbose		 (unsigned int octal, char* read_str,
 																		char* write_str,		char* exec_str);
 /* You can jump into function definitions by regex ^function_name */
 

--- a/prints.c
+++ b/prints.c
@@ -13,15 +13,6 @@
 
 /* Printing Functions */
 void
-print_numeric(Perm *perm) {
-	if (specialp) printf("%04o\n", perm->numeric);
-	else					printf("%03o\n", perm->numeric);
-}
-
-void
-print_symbolic(Perm *perm) { printf("%s\n", perm->symbolic); }
-
-void
 print_verbose(Perm *perm) {
 	printf("user: %s\n", numeric_to_verbose((perm->numeric & 0700) >> 6, NULL, NULL, NULL));
 	printf("group: %s\n", numeric_to_verbose((perm->numeric & 0070) >> 3, NULL, NULL, NULL));

--- a/prints.c
+++ b/prints.c
@@ -1,6 +1,6 @@
 // vim: ts=2 shiftwidth=2 noexpandtab
 
-/* 
+/*
  * per - Simple unix permission viewer and converter
  *
  * This program is licensed under GPL version 3.
@@ -14,8 +14,8 @@
 /* Printing Functions */
 void
 print_numeric(Perm *perm) {
-	if (specialp) printf("%04o\n", perm->numeric); 
-	else					printf("%03o\n", perm->numeric); 
+	if (specialp) printf("%04o\n", perm->numeric);
+	else					printf("%03o\n", perm->numeric);
 }
 
 void


### PR DESCRIPTION
- Removing Leading whitespace
- Replacing `execvp()` with `execl()`
- Collapsing some printing functions from prints.c into per.c
- Use of ternary operators
- Removing unneeded `break` after `exit()` calls