### PR TITLE
Test script, refactor numeric_to_verbose and numeric_to_symbolic, -h EINVAL message removed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ ifeq ($(DEBUG), true)
 	CFLAGS += -g
 endif
 
-.PHONY: install install-doc install-bin uninstall build clean tarball
+.PHONY: install install-doc install-bin uninstall build clean tarball test
 
 # Default
 build: $(BIN)
@@ -67,6 +67,10 @@ endif
 # Building
 $(BIN): $(CSRC) $(HEADERS)
 	$(CC) -o $(BIN) $(CFLAGS) $(CSRC)
+
+# Testing
+test: $(BIN)
+	./test.sh
 
 # Cleaning
 clean:

--- a/conv.c
+++ b/conv.c
@@ -78,24 +78,18 @@ symbolic_to_numeric(char *str) {
 char*
 numeric_to_verbose(unsigned int octal, char* read_str, char* write_str, char* exec_str) {
 	/* Converts 3 bits into symbolic */
-	char* comma_str = ", ";
 	if (!read_str)	 read_str = "read";
 	if (!write_str)  write_str = "write";
 	if (!exec_str)	 exec_str = "execute";
 
+	char* strs[] = {read_str, write_str, exec_str};
 	char* buff_str = calloc(22, sizeof(char));
 
-	/* Bad but works */
-	if (octal & 04) strcpy(buff_str, read_str);
-	if (octal & 02) {
-		if (buff_str[0] != '\0')
-			buff_str = strcat(buff_str, comma_str);
-		buff_str = strcat(buff_str, write_str);
-	}
-	if (octal & 01) {
-		if (buff_str[0] != '\0')
-			buff_str = strcat(buff_str, comma_str);
-		buff_str = strcat(buff_str, exec_str);
+	for (int i = 04; i; i >>= 1) {
+		if (octal & i) {
+			if (*buff_str) strcat(buff_str, ", ");
+			buff_str = strcat(buff_str, strs[2-(i>>1)]);
+		}
 	}
 
 	return buff_str;

--- a/conv.c
+++ b/conv.c
@@ -75,14 +75,9 @@ symbolic_to_numeric(char *str) {
 	return (numeric);
 } /* End of symbolic_to_numeric() */
 
+/* Converts 3 bits into symbolic */
 char*
-numeric_to_verbose(unsigned int octal, char* read_str, char* write_str, char* exec_str) {
-	/* Converts 3 bits into symbolic */
-	if (!read_str)	 read_str = "read";
-	if (!write_str)  write_str = "write";
-	if (!exec_str)	 exec_str = "execute";
-
-	char* strs[] = {read_str, write_str, exec_str};
+numeric_to_verbose(unsigned int octal, char* strs[]) {
 	char* buff_str = calloc(22, sizeof(char));
 
 	for (int i = 04; i; i >>= 1) {

--- a/conv.c
+++ b/conv.c
@@ -10,41 +10,20 @@
 
 #include "per.h"
 
+// Format access mode into a rwxrwxrwx string
 char *
 numeric_to_symbolic(uint16_t num) {
-	char *symbolic = calloc(10, sizeof(char));
-	const char chars[] = "rwxrwxrwx";
-	const char chars_spec[] = "sstSST";
-	uint8_t numeric_len = 9;
+	char *buf = calloc(10, sizeof(char));
 
-	/*
-	 * Checks num bit by bit from left. If bit nth is 1 then fill the nth place
-	 * in `symbolic' with nth char from `chars[]', otherwise fill it with a '-'.
-	 */
-	for (unsigned int i = 0; i < numeric_len; i++) {
-		symbolic[i] = (num & (1 << (8-i))) ? chars[i] : '-';
+	// Revised Toybox lib/lib.c mode_to_string()
+	for (int i = 0; i < 9; i++) {
+		int bit = num & (1 << i), rwx = i % 3;
+		if (!rwx && (num & (1 << ((i / 3) + 9)))) {
+			buf[8-i] = "tss"[i/3];
+			if (!bit) buf[8-i] &= ~0x20;
+		} else buf[8-i] = bit ? "xwr"[rwx] : '-';
 	}
-
-	if (specialp) {
-		/* Similar to above, but checks 3 bits from the left */
-		for (unsigned int i = 0; i < 3; i++) {
-			/* Check if nth bit frm the beginning is 1 */
-			if (num & (1 << (11 - i))) {
-				/*
-				 * Check if corresponding bit from non-special notation is empty
-				 * and apply uppercase or lowercase char appropriately.
-				 */
-				if (num & (1 << (8 - ((i + 1) * 3) + 1)))
-					symbolic[((i + 1) * 3) - 1] = chars_spec[i];
-				else
-					symbolic[((i + 1) * 3) - 1] = chars_spec[i + 3];
-			}
-		}
-	}
-	
-	symbolic[9] = '\0';
-
-	return (symbolic);
+	return buf;
 } /* End of numeric_to_symbolic() */
 
 uint16_t

--- a/per.c
+++ b/per.c
@@ -32,13 +32,14 @@ main(int argc, char **argv) {
 
 	/* If only one arg is supplied respawn with `-vns' */
 	if (argc == 2) {
-		execl(argv[0], argv[0], "-vns", argv[1], NULL);
+		if (strcmp(argv[1], "-h"))
+		  execl(argv[0], argv[0], "-vns", argv[1], NULL);
+		else { usage(); exit(0); }
 	}
 
 	/* The same as above but runs when only `-S' is passed */
-	if (argc == 3 && (strcmp(argv[1], "-S")) == 0) {
+	if (argc == 3 && (strcmp(argv[1], "-S")) == 0)
 		execl(argv[0], argv[0], "-Svns", argv[2], NULL);
-	}
 
 	/* Allocate space for permissions converted into a struct */
 	Perm *perm = calloc(1, sizeof(Perm));

--- a/per.h
+++ b/per.h
@@ -11,24 +11,17 @@
 #ifndef PER_H
 #define PER_H
 
-/* errc on *BSD, error on GNU/Linux */
-#if defined(__linux__)
-	#include <error.h>
-	#define ERR(eval, fmt, ...) error(eval, fmt, __VA_ARGS__)
-#elif defined(__unix__) || defined(__APPLE__)
-	#include <err.h>
-	#define ERR(eval, fmt, ...) errc(eval, fmt, __VA_ARGS__)
-#endif
-
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <err.h>
 
 #define TRUE 1
 #define FALSE 0
 
 #define LEN(arr) (sizeof(arr) / sizeof(arr[0]))
+#define ERR(eval, fmt, ...) err(eval && ((errno = fmt) || 1), __VA_ARGS__)
 
 /* Permision from the arg is converted into this struct */
 typedef struct __perm {

--- a/per.h
+++ b/per.h
@@ -21,7 +21,7 @@
 #define FALSE 0
 
 #define LEN(arr) (sizeof(arr) / sizeof(arr[0]))
-#define ERR(eval, fmt, ...) err(eval && ((errno = fmt) || 1), __VA_ARGS__)
+#define ERR(eval, fmt, ...) do { errno = fmt; err(eval, __VA_ARGS__); } while (0)
 
 /* Permision from the arg is converted into this struct */
 typedef struct __perm {

--- a/per.h
+++ b/per.h
@@ -57,8 +57,7 @@ void				usage									 ();
 /* conv.c */
 char			 *numeric_to_symbolic		 (uint16_t num);
 uint16_t		symbolic_to_numeric		 (char* str);
-char			 *numeric_to_verbose		 (unsigned int octal, char* read_str,
-																		char* write_str,		char* exec_str);
+char			 *numeric_to_verbose		 (unsigned int octal, char* strs[]);
 /* You can jump into function definitions by regex ^function_name */
 
 /* End of Function Prototypes */

--- a/prints.c
+++ b/prints.c
@@ -11,15 +11,18 @@
 
 #include "per.h"
 
+char* regular_pnames[] = {"read", "write", "execute"};
+char* special_pnames[] = {"suid", "sgid", "sticky"};
+
 /* Printing Functions */
 void
 print_verbose(Perm *perm) {
-	printf("user: %s\n", numeric_to_verbose((perm->numeric & 0700) >> 6, NULL, NULL, NULL));
-	printf("group: %s\n", numeric_to_verbose((perm->numeric & 0070) >> 3, NULL, NULL, NULL));
-	printf("other: %s\n", numeric_to_verbose((perm->numeric & 0007), NULL, NULL, NULL));
+	printf("user: %s\n", numeric_to_verbose((perm->numeric & 0700) >> 6, regular_pnames));
+	printf("group: %s\n", numeric_to_verbose((perm->numeric & 0070) >> 3, regular_pnames));
+	printf("other: %s\n", numeric_to_verbose((perm->numeric & 0007), regular_pnames));
 	
 	if (specialp) {
-		printf("special: %s\n", numeric_to_verbose((perm->numeric & 07000) >> 9, "suid", "sgid", "sticky"));
+		printf("special: %s\n", numeric_to_verbose((perm->numeric & 07000) >> 9, special_pnames));
 	}
 	
 } /* End of print_verbose */

--- a/test.sh
+++ b/test.sh
@@ -8,7 +8,7 @@ cd $TESTDIR
 testing () {
   $CMD $1 > got || echo "WARNING: $1 exited $?"
   printf "$2\n" > wanted
-  ! diff -u $TESTDIR/wanted $TESTDIR/got
+  ! diff -u "$TESTDIR/wanted" "$TESTDIR/got"
   printf "\033[1;%sm%s\033[0m\n" "$((31+$?))" "$1"
 }
 

--- a/test.sh
+++ b/test.sh
@@ -7,7 +7,7 @@ cd $TESTDIR
 # testing "args" "expected", green if passed, red if failed
 testing () {
   $CMD $1 > got || echo "WARNING: $1 exited $?"
-  printf "$2\n" > wanted
+  printf "%s\n" "$2" > wanted
   ! diff -u "$TESTDIR/wanted" "$TESTDIR/got"
   printf "\033[1;%sm%s\033[0m\n" "$((31+$?))" "$1"
 }
@@ -18,10 +18,26 @@ chmod 7520 f7520
 # Compact Expected Result string
 R="read" W="write" X="execute"
 
-testing "0000" "user: \ngroup: \nother: \n000\n---------"
-testing "120" "user: $X\ngroup: $W\nother: \n120\n--x-w----"
-testing "-S 4567" "user: $R, $X\ngroup: $R, $W\n\
-other: $R, $W, $X\nspecial: suid\n4567\nr-srw-rwx"
+testing "0000" "user: 
+group: 
+other: 
+000
+---------"
+testing "120" "user: $X
+group: $W
+other: 
+120
+--x-w----"
+testing "-S 4567" "user: $R, $X
+group: $R, $W
+other: $R, $W, $X
+special: suid
+4567
+r-srw-rwx"
 testing "-Sn rwxr-xr-x" "0755"
-testing "-Sns f7520" "7520\nr-s-wS--T"
-testing "-nv f777" "777\nuser: $R, $W, $X\ngroup: $R, $W, $X\nother: $R, $W, $X"
+testing "-Sns f7520" "7520
+r-s-wS--T"
+testing "-nv f777" "777
+user: $R, $W, $X
+group: $R, $W, $X
+other: $R, $W, $X"

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+: "${CMD:=$(realpath per)}"
+TESTDIR=$(mktemp -d)
+trap "rm -rf $TESTDIR" 0
+cd $TESTDIR
+
+# testing "args" "expected", green if passed, red if failed
+testing () {
+  $CMD $1 > got || echo "WARNING: $1 exited $?"
+  printf "$2\n" > wanted
+  ! diff -u $TESTDIR/wanted $TESTDIR/got
+  echo "\033[1;$((31+$?))m$1\033[0m"
+}
+
+touch f777 f7520
+chmod 777 f777
+chmod 7520 f7520
+# Compact Expected Result string
+R="read" W="write" X="execute"
+
+testing "0000" "user: \ngroup: \nother: \n000\n---------"
+testing "120" "user: $X\ngroup: $W\nother: \n120\n--x-w----"
+testing "-S 4567" "user: $R, $X\ngroup: $R, $W\n\
+other: $R, $W, $X\nspecial: suid\n4567\nr-srw-rwx"
+testing "-Sn rwxr-xr-x" "0755"
+testing "-Sns f7520" "7520\nr-s-wS--T"
+testing "-nv f777" "777\nuser: $R, $W, $X\ngroup: $R, $W, $X\nother: $R, $W, $X"

--- a/test.sh
+++ b/test.sh
@@ -9,7 +9,7 @@ testing () {
   $CMD $1 > got || echo "WARNING: $1 exited $?"
   printf "$2\n" > wanted
   ! diff -u $TESTDIR/wanted $TESTDIR/got
-  echo "\033[1;$((31+$?))m$1\033[0m"
+  printf "\033[1;%sm%s\033[0m\n" "$((31+$?))" "$1"
 }
 
 touch f777 f7520


### PR DESCRIPTION
- Concise testing script with test cases and a "test" makefile rule
- Remove per -h EINVAL message (i.e. `./per -h` with no other args)
- Revised numeric_to_verbose() into a single loop, takes a array instead of 3 strings
- Replace numeric_to_symbolic() with heavily modified https://github.com/landley/toybox/blob/a2c4a/lib/lib.c#L1033 (~30 Lines -> 10 Lines)