### PR TITLE
Srink symbolic_to_numeric(), Remove expt(), Redundant Typecasting, __perm.initialzed replaced with NULL when uninitialzed

### DIFF
--- a/conv.c
+++ b/conv.c
@@ -30,7 +30,7 @@ uint16_t
 symbolic_to_numeric(char *str) {
 	uint16_t numeric = 0;
 
-	for (unsigned bit = 0; bit < 9; bit++) {
+	for (unsigned int bit = 0; bit < 9; bit++) {
 		if (str[bit] != '-') {
 			if (strchr("stST", str[bit])) {
 				numeric += 01000 * (1 << (2 - (bit/3)));

--- a/conv.c
+++ b/conv.c
@@ -28,30 +28,20 @@ numeric_to_symbolic(uint16_t num) {
 
 uint16_t
 symbolic_to_numeric(char *str) {
-	char special[] = "stST";
-
 	uint16_t numeric = 0;
-	for (unsigned int field = 0; field < 3; field++) {
-		for (unsigned int bit = 0; bit < 3; bit++) {
-			if (str[field * 3 + bit] != '-') {
-				if (specialp) {
-					for (unsigned int i = 0; i < LEN(special); i++) {
-						if (str[field * 3 + bit] == special[i]) {
-							numeric += 01000 * (1 << (2 - field));
-							break;
-						}
-					}
-					if (str[field * 3 + bit] != 'S' &&
-							str[field * 3 + bit] != 'T') {
-						numeric += expt(8, 2 - field) * (1 << (2 - bit));
-					}
-				}
-				else numeric += expt(8, 2 - field) * (1 << (2 - bit));
+
+	for (unsigned bit = 0; bit < 9; bit++) {
+		if (str[bit] != '-') {
+			if (strchr("stST", str[bit])) {
+				numeric += 01000 * (1 << (2 - (bit/3)));
+			}
+			if (str[bit] != 'S' && str[bit] != 'T') {
+				numeric += (1 << (3*(2 - (bit/3)))) * (1 << (2 - (bit%3)));
 			}
 		}
 	}
 	
-	return (numeric);
+	return numeric;
 } /* End of symbolic_to_numeric() */
 
 /* Converts 3 bits into symbolic */

--- a/misc.c
+++ b/misc.c
@@ -10,16 +10,6 @@
 
 #include "per.h"
 
-int
-expt(int x, unsigned int exp) {
-	/* This implementation is lacking but there's no need for more */
-	int res = 1;
-	for ( ; exp != 0; exp--) res *= x;
-	
-	return res;
-} /* End of expt() */
-
-
 _Bool
 symbolicp(char *str) {
 	char chars[] = "rwx";

--- a/per.c
+++ b/per.c
@@ -42,7 +42,7 @@ main(int argc, char **argv) {
 		execl(argv[0], argv[0], "-Svns", argv[2], NULL);
 
 	/* Allocate space for permissions converted into a struct */
-	Perm *perm = calloc(1, sizeof(Perm));
+	Perm *perm = NULL;
 
 	/* Cleaner syntax */
 	char *target = argv[argc-1];
@@ -60,16 +60,16 @@ main(int argc, char **argv) {
 				specialp = TRUE;
 				break;
 			case 'n':
-				if (!perm->initialized) perm = new_perm_from_value(target);
+				if (!perm) perm = new_perm_from_value(target);
 				printf("%0*o\n", specialp ? 4 : 3, perm->numeric);
 				break;
 			case 's':
-				if (!perm->initialized) perm = new_perm_from_value(target);
+				if (!perm) perm = new_perm_from_value(target);
 				puts(perm->symbolic);
 				break;
 			case 'v':
-				if (!perm->initialized) perm = new_perm_from_value(target);
-				print_verbose(perm);
+				if (!perm) perm = new_perm_from_value(target);
+				print_verbose(perm->numeric);
 				break;
 			case 'h':
 				usage();
@@ -137,8 +137,6 @@ new_perm_from_value(char *target) {
 		usage();
 		ERR(1, EINVAL, "%s", target);
 	}
-
-	perm->initialized = TRUE;
 
 	return perm;
 } /* End of new_perm_from_value() */

--- a/per.c
+++ b/per.c
@@ -41,7 +41,6 @@ main(int argc, char **argv) {
 	if (argc == 3 && (strcmp(argv[1], "-S")) == 0)
 		execl(argv[0], argv[0], "-Svns", argv[2], NULL);
 
-	/* Allocate space for permissions converted into a struct */
 	Perm *perm = NULL;
 
 	/* Cleaner syntax */

--- a/per.c
+++ b/per.c
@@ -47,7 +47,7 @@ main(int argc, char **argv) {
 	/* Cleaner syntax */
 	char *target = argv[argc-1];
 
-	/* If targer is a `-', read target from stdin */
+	/* If target is a `-', read target from stdin */
 	if (strcmp(target, "-") == 0) {
 		fscanf(stdin, "%s", target);
 	}
@@ -94,7 +94,7 @@ new_perm_from_value(char *target) {
 	long numeric = strtol(target, &endptr, 8);
 
 	/* Exit if ``NUMERIC'' is negative or is longer than ``BITN'' bits	*/
-	if (numeric < 0 || (numeric >> bitn) != 0)	{
+	if (numeric >> bitn) {
 		usage();
 		ERR(1, EINVAL, "Incorrect numeric notation");
 	}
@@ -104,8 +104,8 @@ new_perm_from_value(char *target) {
 	 * ``TARGET'' is a number.
 	 */
 	if (*endptr == '\0') {
-		perm->numeric = (uint16_t) numeric;
-		perm->symbolic = numeric_to_symbolic((uint16_t) numeric);
+		perm->numeric  = numeric;
+		perm->symbolic = numeric_to_symbolic(numeric);
 	}
 
 	/* Runs if ``TARGET'' is a valid path */
@@ -121,11 +121,10 @@ new_perm_from_value(char *target) {
 			ERR(errno, errno, "Race condition cought, file %s modified.", target);
 		}
 
-		numeric = statbuf.st_mode & (S_IRWXU + S_IRWXG + S_IRWXO);
-		if (specialp) numeric += statbuf.st_mode & 07000;
+		numeric = statbuf.st_mode & (0777 + (specialp ? 07000 : 0));
 
-		perm->numeric = (uint16_t) numeric;
-		perm->symbolic = numeric_to_symbolic((uint16_t) numeric);
+		perm->numeric  = numeric;
+		perm->symbolic = numeric_to_symbolic(numeric);
 	}
 
 	/* Runs if TARGET is a valid symbolic notation */

--- a/per.h
+++ b/per.h
@@ -26,8 +26,8 @@
 /* Permision from the arg is converted into this struct */
 typedef struct __perm {
 	uint16_t		numeric;
-	char			 *symbolic;
-	_Bool				initialized;
+	char			*symbolic;
+	_Bool			initialized;
 } Perm;
 
 /* Should we treat notations as special? */

--- a/per.h
+++ b/per.h
@@ -27,7 +27,6 @@
 typedef struct __perm {
 	uint16_t		numeric;
 	char			*symbolic;
-	_Bool			initialized;
 } Perm;
 
 /* Should we treat notations as special? */
@@ -41,9 +40,7 @@ Perm			 *new_perm_from_value		 (char *target);
 _Bool				symbolicp							 (char *str);
 
 /* prints.c */
-void				print_numeric					 (Perm *perm);
-void				print_symbolic				 (Perm *perm);
-void				print_verbose					 (Perm *perm);
+void				print_verbose					 (uint16_t numeric);
 void				usage									 ();
 
 /* conv.c */

--- a/per.h
+++ b/per.h
@@ -38,7 +38,6 @@ extern _Bool specialp;
 Perm			 *new_perm_from_value		 (char *target);
 
 /* misc.c */
-int					expt									 (int x, unsigned int exp);
 _Bool				symbolicp							 (char *str);
 
 /* prints.c */

--- a/prints.c
+++ b/prints.c
@@ -16,13 +16,13 @@ char* special_pnames[] = {"suid", "sgid", "sticky"};
 
 /* Printing Functions */
 void
-print_verbose(Perm *perm) {
-	printf("user: %s\n", numeric_to_verbose((perm->numeric & 0700) >> 6, regular_pnames));
-	printf("group: %s\n", numeric_to_verbose((perm->numeric & 0070) >> 3, regular_pnames));
-	printf("other: %s\n", numeric_to_verbose((perm->numeric & 0007), regular_pnames));
+print_verbose(uint16_t numeric) {
+	printf("user: %s\n", numeric_to_verbose((numeric & 0700) >> 6, regular_pnames));
+	printf("group: %s\n", numeric_to_verbose((numeric & 0070) >> 3, regular_pnames));
+	printf("other: %s\n", numeric_to_verbose((numeric & 0007), regular_pnames));
 	
 	if (specialp) {
-		printf("special: %s\n", numeric_to_verbose((perm->numeric & 07000) >> 9, special_pnames));
+		printf("special: %s\n", numeric_to_verbose((numeric & 07000) >> 9, special_pnames));
 	}
 	
 } /* End of print_verbose */

--- a/test.sh
+++ b/test.sh
@@ -41,3 +41,5 @@ testing "-nv f777" "777
 user: $R, $W, $X
 group: $R, $W, $X
 other: $R, $W, $X"
+testing "-Sn rwSrwsrwT" "7676"
+testing "-Sn rwsrwSr-t" "7765"


### PR DESCRIPTION
- Shrink `symbolic_to_numeric()`:
  * specialp checks aren't needed since `symbolicp()` does it already
  * use `strchr()` instead of manual for loop check
  * `expt()` can be replaced by a simple bit shift (8<sup>x</sup> = (2<sup>3</sup>)<sup>x</sup> = 2<sup>3\*x</sup> = `1 << (3*x)`)
- Most typecasting is redundant and automatically done by the compiler
  * `numeric < 0 || (numeric >> bitn) != 0` is redundant (-1 >> n = -1 != 0)
- Remove unneeded `calloc()` call and small memory leak by replacing `perm->initialized` with setting `perm` to a NULL pointer when uninitialized 